### PR TITLE
fix: Clarify 'books' domain areas

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -9,7 +9,7 @@ What this styleguide calls a `domain` is roughly an extension of what Django wou
 > ### Examples in this guide
 
 > The examples in this guide will talk about a `book shop` that shares details about books.
-> This can be modelled as a _domain_ called `books`, and as a _software domain_ also called `books`.
+> This can be modelled as a _business domain_ called `books`, and as a _software domain_ also called `books`.
 
 ---
 


### PR DESCRIPTION
In the previous paragraph there is mention of the 'business domain' and the 'software domain' but then in the example one of them is simply referred to as the 'domain'